### PR TITLE
point NAME for the WriteMakefile() arg to the package that exists

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,7 +7,8 @@ use warnings;
 use ExtUtils::MakeMaker;
 
 WriteMakefile(
-  NAME    => 'TimeDate',
+  NAME    => 'Date::Format',
+  DISTNAME => 'TimeDate',
   AUTHOR  => 'Graham Barr <gbarr@pobox.com>',
   VERSION => '1.20',
   (eval { ExtUtils::MakeMaker->VERSION(6.21) } ? (LICENSE => 'perl') : ()),


### PR DESCRIPTION
re: https://rt.cpan.org/Public/Bug/Display.html?id=83141

Keep DISTNAME to TimeDate so that META.yml and generated tarball will still have TimeDate, which is a valid name as a distribution name, but not a module name.
