### PR TITLE
add missing =back to Date::Parse POD

### DIFF
--- a/lib/Date/Parse.pm
+++ b/lib/Date/Parse.pm
@@ -322,6 +322,8 @@ if they could be extracted from the date string. The C<$zone> element is
 the timezone offset in seconds from GMT. An empty array is returned upon
 failure.
 
+=back
+
 =head1 MULTI-LANGUAGE SUPPORT
 
 Date::Parse is capable of parsing dates in several languages, these include


### PR DESCRIPTION
running perldoc on Date::Parse includes the following message in the output:

```
POD ERRORS
       Hey! The above document had some coding errors, which are explained below:

       Around line 325:
           You forgot a '=back' before '=head1'
```

This change suppresses the error.
