### PR TITLE
Fix for French language using English day suffixes

### DIFF
--- a/lib/Date/Language/French.pm
+++ b/lib/Date/Language/French.pm
@@ -32,5 +32,6 @@ sub format_b { $MoYs[$_[0]->[4]] }
 sub format_B { $MoY[$_[0]->[4]] }
 sub format_h { $MoYs[$_[0]->[4]] }
 sub format_p { $_[0]->[2] >= 12 ?  $AMPM[1] : $AMPM[0] }
+sub format_o { sprintf("%2de",$_[0]->[3]) }
 
 1;


### PR DESCRIPTION
```perl
# Before: jan 30th 2019
# After:  jan 30e 2019
Date::Language->new('French')->time2str( "%b %o %Y", time() );
```