### PR TITLE
Fix getdate.t test

### DIFF
--- a/t/getdate.t
+++ b/t/getdate.t
@@ -156,7 +156,7 @@ Jul 22 10:00:00 UTC 2002	     ;1027332000
 !;
 
 require Time::Local;
-my $offset = Time::Local::timegm(0,0,0,1,0,70);
+my $offset = Time::Local::timegm(0,0,0,1,0,1970);
 
 @data = split(/\n/, $data);
 


### PR DESCRIPTION
This fixes building the module in the year 2020 per the information at
http://blogs.perl.org/users/grinnz/2019/07/the-timelocal-trap.html.

Signed-off-by: Sol Jerome <solj@utdallas.edu>